### PR TITLE
handling no common factor case

### DIFF
--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -117,6 +117,9 @@ function SimModel(; kwargs...)
         # cholL = cholesky(cov(η')).L
         # η = inv(cholL) * η
         Λ = rand(N, K)
+    else
+        Λ = rand(N, 0)
+        η = rand(0, T)
     end
 
     if K > 0


### PR DESCRIPTION
Hi Julie. Will run into an issue if we run simulation with no common factor i.e. K = 0

```
Generating simulation with params:
(T = 3, N = 2, K = 0, M = 0.5, σζ = 1.0, missingperc = 0.0)
ERROR: UndefVarError: `Λ` not defined in local scope
Suggestion: check for an assignment to a local variable that shadows a global of the same name.
```

A simple fix will be like below.